### PR TITLE
doc: control warnings at code-block and file level

### DIFF
--- a/guide/_sidebar.yml
+++ b/guide/_sidebar.yml
@@ -1,6 +1,3 @@
-execute:
-  warning: false
-
 website:
   page-navigation: true
   sidebar:

--- a/guide/aesthetic-mappings.qmd
+++ b/guide/aesthetic-mappings.qmd
@@ -1,6 +1,9 @@
 ---
 title: Aesthetic mappings
 jupyter: python3
+execute:
+  # disable warnings for missing values in penguins dataset
+  warning: false
 ---
 
 The `aes()` function maps columns of data onto graphical attributes--such as colors, shapes, or x and y coordinates. (`aes()` is short for aesthetic). It can be specified at the plot level, as well as at the individual geom level.

--- a/guide/annotations.qmd
+++ b/guide/annotations.qmd
@@ -33,6 +33,7 @@ from plotnine.data import penguins
 Use `annotate()` to write some text on a plot.
 
 ```{python}
+#| warning: false
 r_coef = penguins["flipper_length_mm"].corr(penguins["body_mass_g"])
 p = (
     ggplot(penguins, aes("flipper_length_mm", "body_mass_g"))
@@ -56,6 +57,7 @@ Notice that the correlation coefficient is shown on the top-left of the plot. Th
 In order to use annotate with another geom, pass the name of the geom as the first argument. For example, the code below draws a rectangle around the text.
 
 ```{python}
+#| warning: false
 p + annotate("rect", xmin=170, xmax=190, ymin=5500, ymax=6000, color="blue", fill=None)
 ```
 
@@ -66,6 +68,7 @@ Note that `annotate()` takes the same arguments as the corresponding `geom_*()` 
 Use the `geom_text(path_effects=...)` argument to add more complex styling to your text. This argument takes a list of objects created by the `matplotlib.patheffects` submodule.
 
 ```{python}
+#| warning: false
 import matplotlib.patheffects as pe
 
 effect = [

--- a/guide/coordinate-systems.qmd
+++ b/guide/coordinate-systems.qmd
@@ -76,7 +76,7 @@ p + coord_cartesian(ylim = [5000, None])
 
 Notice that the second plot is zoomed in, so the y-axis starts at the top of the boxplots.  Importantly, `coord_cartesian()` doesn't affect any statistical calculations.
 
-By contrast, setting limits in scales [excludes](scale-basics.qmd#limits-missing-data) any data outside those limits.
+By contrast, [setting limits in scales](scale-basics.qmd#limits-for-restricting-data-range) excludes any data outside those limits.
 
 ```{python}
 p + scale_y_continuous(limits = [5000, None])

--- a/guide/coordinate-systems.qmd
+++ b/guide/coordinate-systems.qmd
@@ -76,7 +76,7 @@ p + coord_cartesian(ylim = [5000, None])
 
 Notice that the second plot is zoomed in, so the y-axis starts at the top of the boxplots.  Importantly, `coord_cartesian()` doesn't affect any statistical calculations.
 
-By contrast, setting limits in scales excludes any data outside those limits.
+By contrast, setting limits in scales [excludes](scale-basics.qmd#limits-missing-data) any data outside those limits.
 
 ```{python}
 p + scale_y_continuous(limits = [5000, None])

--- a/guide/export.qmd
+++ b/guide/export.qmd
@@ -32,6 +32,7 @@ By default, plots in Jupyter and Quarto should be displayed automatically.
 For example, this website is built with Quarto, but the code below should also cause a plot to appear in a Jupyter notebook.
 
 ```{python}
+#| warning: false
 p = (
     ggplot(penguins, aes("bill_length_mm", "bill_depth_mm", color="species"))
     + geom_point()
@@ -48,6 +49,7 @@ p
 If you want to explicitly display a plot, use the `.show()` method.
 
 ```{python}
+#| warning: false
 p.show()
 ```
 

--- a/guide/facets.qmd
+++ b/guide/facets.qmd
@@ -22,7 +22,7 @@ Facets split a plot into multiple subplots, based on one or more variables. `fac
 
 ```{python}
 from plotnine import *
-from plotnine.data import mpg, penguins
+from plotnine.data import mpg
 ```
 
 Here is a single big plot that you might want to split into subplots.

--- a/guide/introduction.qmd
+++ b/guide/introduction.qmd
@@ -63,6 +63,7 @@ The scatterplot below shows the relationship between bill length and bill depth 
 
 
 ```{python}
+#| warning: false
 from plotnine import ggplot, aes, geom_point, labs
 from plotnine.data import penguins
 
@@ -80,6 +81,7 @@ It also provides simple a `>>` operator to pipe data into a plot.
 The example below shows a Polars DataFrame being filtered, then piped into a plot.
 
 ```{python}
+#| warning: false
 import polars as pl
 
 pl_penguins = pl.from_pandas(penguins)

--- a/guide/labels.qmd
+++ b/guide/labels.qmd
@@ -1,6 +1,9 @@
 ---
 title: Labels and titles
 jupyter: python3
+execute:
+  # disable warnings for missing values in penguins dataset
+  warning: false
 ---
 
 :::{.callout-tip title="You will learn"}

--- a/guide/scale-basics.qmd
+++ b/guide/scale-basics.qmd
@@ -219,6 +219,8 @@ p + scale_x_continuous(limits=[1950, 1960]) + labs(title="zoom in")
 p + scale_x_continuous(limits=[1800, 2000]) + labs(title="zoom out")
 ```
 
+[By _default_, when you "zoom in" by restricting the limits of the scale and have any data outside go out of bounds, it becomes unrepresentable by the scale. Unrepresentable data falls within the "missing data" category data, and it cannot be plotted so it is dropped with a warning.]{#limits-missing-data}
+
 ```{python}
 #| layout-nrow: 1
 p = ggplot(huron, aes("year", "level", color="year")) + geom_line() 

--- a/guide/scale-basics.qmd
+++ b/guide/scale-basics.qmd
@@ -4,6 +4,20 @@ jupyter: python3
 ipynb-shell-interactivity: all
 ---
 
+```{python}
+# | include: false
+# TODO: need more general approach for shortening warnings in docs
+import warnings
+from warnings import WarningMessage, _formatwarnmsg_impl
+
+
+def new_formatwarning(message, category, filename, lineno, line=None):
+    return f"{category.__name__}: {message}\n"
+
+
+warnings.formatwarning = new_formatwarning
+```
+
 Scales specify how aesthetic mappings are ultimately styled as colors, shapes, positions, sizes, and more. This includes choosing the colors used or scaling the size of points based on values of data.
 
 Scale functions follow the naming pattern `scale_{aesthetic}_{type}`, where aesthetic is the name of the mapping (e.g. `x`, `y`, `fill`, `shape`), and type is the type of scale (e.g. `continuous`, `discrete`, `color`, `shape`).
@@ -219,7 +233,12 @@ p + scale_x_continuous(limits=[1950, 1960]) + labs(title="zoom in")
 p + scale_x_continuous(limits=[1800, 2000]) + labs(title="zoom out")
 ```
 
-[By _default_, when you "zoom in" by restricting the limits of the scale and have any data outside go out of bounds, it becomes unrepresentable by the scale. Unrepresentable data falls within the "missing data" category data, and it cannot be plotted so it is dropped with a warning.]{#limits-missing-data}
+Notice two important pieces:
+
+* The second plot is more zoomed in, so excludes some data (e.g. years before 1950).
+* The `PlotnineWarning` printed before the plots comes from the zoomed in plot, and indicates that zooming in cut off 87 rows. When data falls outside limits, Plotnine treats them like missing values.
+
+
 
 ```{python}
 #| layout-nrow: 1

--- a/guide/scale-color-fill.qmd
+++ b/guide/scale-color-fill.qmd
@@ -1,6 +1,9 @@
 ---
 title: Scale color and fill
 jupyter: python3
+execute:
+  # disable warnings for missing values in penguins dataset
+  warning: false
 ---
 
 ```{python}

--- a/guide/scale-misc.qmd
+++ b/guide/scale-misc.qmd
@@ -12,7 +12,6 @@ jupyter: python3
 ```{python}
 import pandas as pd
 
-from plotnine.data import penguins
 from plotnine import *
 
 df = pd.DataFrame(

--- a/guide/themes-basics.qmd
+++ b/guide/themes-basics.qmd
@@ -1,6 +1,7 @@
 ---
 title: Theme basics
-execute: 
+execute:
+  # disable warnings for missing values in penguins dataset
   warning: false
 ---
 

--- a/guide/themes-premade.qmd
+++ b/guide/themes-premade.qmd
@@ -2,6 +2,7 @@
 title: Premade themes
 jupyter: python3
 execute:
+  # disable warnings for missing values in penguins dataset
   warning: false
 ---
 


### PR DESCRIPTION
The warnings are all about missing values in the data. Mainly because penguins dataset (used in many pages) has missing data and it is used.

1. Don't display missing value warnings if they have no bearing on the on the code.
2. Do display missing value warnings when it makes sense for the documentation.

Generally, all warnings should only be omitted with reason.

closes: #18