### PR TITLE
add pixi to guide

### DIFF
--- a/guide/install.qmd
+++ b/guide/install.qmd
@@ -48,7 +48,7 @@ $ pip install 'plotnine[extra]'
 $ uv pip install 'plotnine[extra]'
 
 # Using pixi:
-$ pixi add --pypi 'plotnine[extra]'
+$ pixi add 'plotnine[extra]' --pypi
 
 # Using conda:
 $ conda install -c conda-forge 'plotnine[extra]'


### PR DESCRIPTION
The regular release can be installed from the `conda-forge` repo easily. The `[extras]` flavor of `plotnine` can be installed using the [--pypi flag, which used `uv` under the hood](https://pixi.sh/latest/python/tutorial/#managing-both-conda-and-pypi-dependencies-in-pixi).