### PR TITLE
update introduction.qmd to include pixi install instructions

### DIFF
--- a/guide/introduction.qmd
+++ b/guide/introduction.qmd
@@ -40,6 +40,20 @@ uv add plotnine
 uv add 'plotnine[extra]'
 ```
 
+### pixi
+
+```bash
+# simple install
+pixi init name-of-project
+cd name-of-project
+pixi add plotnine
+
+# with dependencies uses in examples
+pixi init name-of-project
+cd name-of-project
+pixi add 'plotnine[extra]' --pypi
+```
+
 ### conda
 
 ```bash


### PR DESCRIPTION
* follows up commit 0db50bab5c0bc39fa1859ba480be441bb075917c
* adds installation instructions earlier in the guide

One thing I wasn't sure of would be if I should use the `--pypi` command in pixi as a part of the default installation. I'm not sure if users would run into issues with mixing conda-forge and pypi dependencies if they tried `pixi add plotnine` and followed it up with `pixi add 'plotnine[extra]' --pypi`.