### PR TITLE
docs: drop Futura base_family from Anscombe example

### DIFF
--- a/guide/introduction.qmd
+++ b/guide/introduction.qmd
@@ -133,7 +133,7 @@ from plotnine.data import anscombe_quartet
     + labs(title="Anscombe’s Quartet")
     + scale_y_continuous(breaks=(4, 8, 12))
     + coord_fixed(xlim=(3, 22), ylim=(2, 14))
-    + theme_tufte(base_family="Futura", base_size=16)
+    + theme_tufte(base_size=16)
     + theme(
         axis_line=element_line(color="#4d4d4d"),
         axis_ticks_major=element_line(color="#00000000"),


### PR DESCRIPTION
Futura isn't guaranteed to be available on readers' systems; falling back to the default font keeps the rendered output consistent.

This gets rid of the warnings at https://plotnine.org/guide/introduction.html